### PR TITLE
fix: no trailing slash

### DIFF
--- a/app/routes/rooms.py
+++ b/app/routes/rooms.py
@@ -7,7 +7,7 @@ router = APIRouter(prefix='/rooms', tags=['Rooms'])
 
 
 @router.get(
-	'/',
+	'', #path here set to /rooms as default
 	response_model=RoomListModel,
 	summary='Get all rooms',
 	tags=['Rooms'],

--- a/app/routes/sensors.py
+++ b/app/routes/sensors.py
@@ -6,7 +6,7 @@ from app.utils.response_examples.sensors import get_sensor_by_id_responses, get_
 router = APIRouter(prefix='/sensors', tags=['Sensors'])
 
 @router.get(
-  '/',
+  '',
   response_model=SensorListModel,
   summary='Get all sensors',
   tags=['Sensors'],


### PR DESCRIPTION
This pull request includes changes to the routes for rooms and sensors in the application. The most important changes involve updating the default paths for these routes.

Route updates:

* [`app/routes/rooms.py`](diffhunk://#diff-5d385e4d1af9ec7b92c45d1fd9fff6c385fe31d145bd718baea75d0f0b2be865L10-R10): Changed the default path for the rooms route to `/rooms`.
* [`app/routes/sensors.py`](diffhunk://#diff-0fd04d951e2ab5e4e0945580404b6f885327005235b124a7ad7991f7e8ffad70L9-R9): Changed the default path for the sensors route to `/sensors`.- removed trailing slash from endpoints (GET all rooms, GET all sensors)